### PR TITLE
API 공통응답과 에러 핸들러

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 //	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	compileOnly 'org.projectlombok:lombok'
 	implementation 'org.postgresql:postgresql'
 	implementation 'org.slf4j:slf4j-api:2.0.0'

--- a/src/main/java/com/appsolve/wearther_backend/apiResponse/ApiResponse.java
+++ b/src/main/java/com/appsolve/wearther_backend/apiResponse/ApiResponse.java
@@ -1,0 +1,25 @@
+package com.appsolve.wearther_backend.apiResponse;
+
+import com.appsolve.wearther_backend.apiResponse.dto.ExceptionDto;
+import com.appsolve.wearther_backend.apiResponse.exception.CustomException;
+import jakarta.annotation.Nullable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public record ApiResponse<T> (
+                             HttpStatus httpStatus,
+                             boolean success,
+                             @Nullable T result,
+                             @Nullable ExceptionDto error) {
+
+    public static <T> ResponseEntity<ApiResponse<T>> success(HttpStatus httpStatus, @Nullable final T result) {
+        ApiResponse<T> response = new ApiResponse<>(httpStatus, true, result, null);
+        return new ResponseEntity<>(response, httpStatus);
+    }
+
+    public static <T> ApiResponse<T> fail(final CustomException e , @Nullable final T result) {
+        return new ApiResponse<>(e.getHttpStatus(), false, result, ExceptionDto.of(e.getErrorCode()));
+    }
+
+
+}

--- a/src/main/java/com/appsolve/wearther_backend/apiResponse/dto/ExceptionDto.java
+++ b/src/main/java/com/appsolve/wearther_backend/apiResponse/dto/ExceptionDto.java
@@ -1,0 +1,23 @@
+package com.appsolve.wearther_backend.apiResponse.dto;
+
+import com.appsolve.wearther_backend.apiResponse.exception.ErrorCode;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ExceptionDto {
+    @NotNull
+    private final String code;
+
+    @NotNull
+    private final String message;
+
+    public ExceptionDto(ErrorCode errorCode) {
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
+    }
+
+    public static ExceptionDto of(ErrorCode errorCode) {
+        return new ExceptionDto(errorCode);
+    }
+}

--- a/src/main/java/com/appsolve/wearther_backend/apiResponse/exception/CustomException.java
+++ b/src/main/java/com/appsolve/wearther_backend/apiResponse/exception/CustomException.java
@@ -1,0 +1,20 @@
+package com.appsolve.wearther_backend.apiResponse.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+    public HttpStatus getHttpStatus() {
+        return errorCode.getHttpStatus();
+    }
+
+}

--- a/src/main/java/com/appsolve/wearther_backend/apiResponse/exception/ErrorCode.java
+++ b/src/main/java/com/appsolve/wearther_backend/apiResponse/exception/ErrorCode.java
@@ -1,0 +1,31 @@
+package com.appsolve.wearther_backend.apiResponse.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+
+
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+    _NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND, "COMMON40400", "존재하지 않는 API입니다."),
+    _NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, "COMMON40401", "요청한 리소스를 찾을 수 없습니다."),
+    _METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON405", "허용되지 않은 요청 방식입니다."),
+    _TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "COMMON429", "너무 많은 요청입니다. 잠시 후 다시 시도해주세요."),
+
+    /*에러 추가 가능*/
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "존재하지 않는 사용자 ID입니다."),
+    USER_NOT_AUTHORIZED(HttpStatus.UNAUTHORIZED, "USER4002", "사용자 인증이 필요합니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+
+
+}

--- a/src/main/java/com/appsolve/wearther_backend/apiResponse/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/appsolve/wearther_backend/apiResponse/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,81 @@
+package com.appsolve.wearther_backend.apiResponse.exception.handler;
+
+import com.appsolve.wearther_backend.apiResponse.ApiResponse;
+import com.appsolve.wearther_backend.apiResponse.exception.CustomException;
+import com.appsolve.wearther_backend.apiResponse.exception.ErrorCode;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice(basePackages = {"com.appsolve.wearther_backend.Controller"})
+public class GlobalExceptionHandler {
+
+    // 존재하지 않는 요청
+    @ExceptionHandler(value = {NoHandlerFoundException.class})
+    public ResponseEntity<ApiResponse<?>> handleNoPageFoundException(Exception e) {
+        log.error("NoHandlerFoundException: {}", e.getMessage());
+        return buildResponse(ErrorCode._NOT_FOUND_END_POINT,null);
+    }
+
+    // 검증 실패 (RequestParam 유효성 검증)
+    @ExceptionHandler(value = {ConstraintViolationException.class})
+    public ResponseEntity<ApiResponse<?>> handleValidationException(ConstraintViolationException e) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .findFirst()
+                .orElse("Validation error occurred");
+        log.error("Validation error: {}", errorMessage);
+        return buildResponse(ErrorCode._BAD_REQUEST, errorMessage);
+    }
+
+    // 검증 실패 (RequestBody 유효성 검증)
+    @ExceptionHandler(value = {MethodArgumentNotValidException.class})
+    public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        Map<String, String> errors = new LinkedHashMap<>();
+        e.getBindingResult().getFieldErrors()
+                .forEach(fieldError -> errors.put(fieldError.getField(), fieldError.getDefaultMessage()));
+        log.error("MethodArgumentNotValidException: {}", errors);
+        return buildResponse(ErrorCode._BAD_REQUEST, errors);
+    }
+
+    // 커스텀 예외
+    @ExceptionHandler(value = {CustomException.class})
+    public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e) {
+        log.error("CustomException: {}", e.getMessage());
+        return buildResponse(e.getErrorCode(), null);
+    }
+
+    @ExceptionHandler(value = {HttpRequestMethodNotSupportedException.class})
+    public ResponseEntity<ApiResponse<?>> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+        log.warn("HttpRequestMethodNotSupportedException: {}", e.getMessage());
+        return buildResponse(ErrorCode._METHOD_NOT_ALLOWED, "허용되지 않은 HTTP 메서드입니다.");
+    }
+
+
+    // 기본 예외
+    @ExceptionHandler(value = {Exception.class})
+    public ResponseEntity<ApiResponse<?>> handleAllException(Exception e) {
+
+        log.error("Unexpected error: {}", e.getMessage());
+        return buildResponse(ErrorCode._INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+
+
+    private ResponseEntity<ApiResponse<?>> buildResponse(ErrorCode errorCode, Object result) {
+        CustomException customException = new CustomException(errorCode);
+        ApiResponse<?> response = ApiResponse.fail(customException, result);
+        return ResponseEntity
+                .status(customException.getHttpStatus())
+                .body(response);
+    }
+}


### PR DESCRIPTION
### ✨ 관련된 이슈
- close #6 

### 🙌 작업 내용
- 공통응답과 에러핸들러를 구현하였습니다.
- 컨트롤러에서 성공시 ApiResponse.success(원하는 HttpStatus,보내고자하는 데이터); 형태로 사용하실 수 있습니다.
-응답형태는
{
  "httpStatus":
  "success": 
  "result": 
  "error":
} 입니다.

### 📸 스크린샷 (선택)
- 성공시
![성공](https://github.com/user-attachments/assets/05cbfc28-d200-4ed6-9e56-14ca934ed44d)
![성공2](https://github.com/user-attachments/assets/5fe0ffc9-5aea-4108-b74a-b7669a215f27)
-에러발생
![에러형태](https://github.com/user-attachments/assets/47abdcda-8437-4400-832d-4bfbb1373253)


### 🤔 리뷰 요구사항(선택)
-  제가 에러 핸들러 구현과 공통응답 구현 두 개 다 처음 해봐서 혹시 부족한 부분 있으시면 꼭 말씀 부탁드립니다!
- 공통응답 구조 형태가 괜찮은지도 한 번 봐주시면 감사하겠습니다!
- swagger 작동이 잘 안 돼서 build.gradle의 SpringDoc OpenAPI 라이브러리의 버전을 바꾸었는데 괜찮으실지 확인 부탁드립니다