### PR TITLE
[FEAT] 체질 관련 api 추가

### DIFF
--- a/src/main/java/com/appsolve/wearther_backend/Controller/MemberController.java
+++ b/src/main/java/com/appsolve/wearther_backend/Controller/MemberController.java
@@ -1,0 +1,28 @@
+package com.appsolve.wearther_backend.Controller;
+
+
+import com.appsolve.wearther_backend.Service.MemberService;
+import com.appsolve.wearther_backend.apiResponse.ApiResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/member")
+public class MemberController {
+    @Autowired
+    private MemberService memberService;
+
+    @GetMapping("/constitution/{memberId}")
+    public ResponseEntity<ApiResponse<Integer>> getConstitution(@PathVariable Long memberId) {
+        int constitution = memberService.getConstitutionByMemberId(memberId);
+        return ApiResponse.success(HttpStatus.OK, constitution);
+    }
+
+    @PatchMapping("/constitution/update/{memberId}/{constitution}")
+    public ResponseEntity<ApiResponse<Integer>> updateMemberConstitution(@PathVariable Long memberId, @PathVariable Integer constitution) {
+        memberService.updateConstitutionByMemberId(memberId, constitution);
+        return ApiResponse.success(HttpStatus.OK, constitution);
+    }
+}

--- a/src/main/java/com/appsolve/wearther_backend/Entity/MemberEntity.java
+++ b/src/main/java/com/appsolve/wearther_backend/Entity/MemberEntity.java
@@ -1,0 +1,20 @@
+package com.appsolve.wearther_backend.Entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "member")
+public class MemberEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memberId;  // Primary key: member_id
+    private String memberEmail;
+    private String loginId;
+    private String userPw;
+    private Integer constitution;
+    private Long closetId;
+
+}

--- a/src/main/java/com/appsolve/wearther_backend/Repository/MemberRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/Repository/MemberRepository.java
@@ -1,0 +1,20 @@
+package com.appsolve.wearther_backend.Repository;
+
+import com.appsolve.wearther_backend.Entity.MemberEntity;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
+    @Query("SELECT m.constitution FROM MemberEntity m WHERE m.id = :memberId")
+    int findConstitutionByMemberId(@Param("memberId") Long memberId);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE MemberEntity m SET m.constitution = :constitution WHERE m.memberId = :memberId")
+    void updateConstitutionByMemberId(@Param("memberId") Long memberId, @Param("constitution") int constitution);
+}

--- a/src/main/java/com/appsolve/wearther_backend/Service/MemberService.java
+++ b/src/main/java/com/appsolve/wearther_backend/Service/MemberService.java
@@ -1,0 +1,25 @@
+package com.appsolve.wearther_backend.Service;
+
+import com.appsolve.wearther_backend.Repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MemberService {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    public int getConstitutionByMemberId(Long memberId){
+        int number = memberRepository.findConstitutionByMemberId(memberId);
+        return number;
+    }
+
+    @Transactional
+    public void updateConstitutionByMemberId(Long memberId, Integer constitution){
+        memberRepository.updateConstitutionByMemberId(memberId, constitution);
+    }
+
+
+}


### PR DESCRIPTION
### ✨ 관련된 이슈
- close #10 

### 🙌 작업 내용
- 사용자가 체질 조회 시 반환 (get)
- 사용자가 체질 변경 시 반영 (patch)

### 📸 스크린샷 (선택)
get :
![0102_4](https://github.com/user-attachments/assets/1c931f7a-985f-4bbc-8c74-4a7b5d02e64b)

patch : (사용자1의 체질 변경)
![0102_5](https://github.com/user-attachments/assets/387a8883-17ed-48ec-be24-db5c7cd577ac)


### 🤔 리뷰 요구사항(선택)
-  체질 자체가 member 내의 컬럼이다 보니 따로 두면 복잡해질 거 같아서 아예 member 를 기준으로 코드 작성했습니다.
- 선희님 회원가입 시 member에 post하는 코드 작성하실 때 여기에 이어서 작성하셔도 문제 없으시겠죠...???
- 참고로 저는 post가 아직 없으니 pgadmin에서는 sql이용해서 더미 데이터 넣고 확인해보았습니다!