### PR TITLE
[FEAT] 내 옷장 조회 및 추천 상품 조회

### DIFF
--- a/src/main/java/com/appsolve/wearther_backend/Entity/MemberEntity.java
+++ b/src/main/java/com/appsolve/wearther_backend/Entity/MemberEntity.java
@@ -1,10 +1,18 @@
 package com.appsolve.wearther_backend.Entity;
 
+import com.appsolve.wearther_backend.closet.entity.Closet;
 import jakarta.persistence.*;
-import lombok.Data;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.FetchType.LAZY;
 
 @Data
-@Entity
+@Entity @Builder
+@NoArgsConstructor
+@AllArgsConstructor @Setter
 @Table(name = "member")
 public class MemberEntity {
 
@@ -15,6 +23,12 @@ public class MemberEntity {
     private String loginId;
     private String userPw;
     private Integer constitution;
-    private Long closetId;
+
+    @OneToOne(fetch = LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "closet_id")
+    private Closet closet;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberTaste> memberTastes = new ArrayList<>(); 
 
 }

--- a/src/main/java/com/appsolve/wearther_backend/Entity/MemberTaste.java
+++ b/src/main/java/com/appsolve/wearther_backend/Entity/MemberTaste.java
@@ -1,0 +1,24 @@
+package com.appsolve.wearther_backend.Entity;
+
+import com.appsolve.wearther_backend.init_data.entity.Taste;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder @Getter
+@Table(name="member_taste")
+public class MemberTaste {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private MemberEntity member;
+
+    @ManyToOne
+    @JoinColumn(name = "taste_id", nullable = false)
+    private Taste taste;
+}

--- a/src/main/java/com/appsolve/wearther_backend/Repository/MemberRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/Repository/MemberRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
-    @Query("SELECT m.constitution FROM MemberEntity m WHERE m.id = :memberId")
+    @Query("SELECT m.constitution FROM MemberEntity m WHERE m.memberId = :memberId")
     int findConstitutionByMemberId(@Param("memberId") Long memberId);
 
     @Modifying

--- a/src/main/java/com/appsolve/wearther_backend/Repository/MemberTasteRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/Repository/MemberTasteRepository.java
@@ -1,0 +1,11 @@
+package com.appsolve.wearther_backend.Repository;
+
+import com.appsolve.wearther_backend.Entity.MemberTaste;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MemberTasteRepository extends JpaRepository<MemberTaste, Long> {
+    List<MemberTaste> findByMemberMemberId(Long memberId);
+}
+

--- a/src/main/java/com/appsolve/wearther_backend/Service/MemberService.java
+++ b/src/main/java/com/appsolve/wearther_backend/Service/MemberService.java
@@ -1,15 +1,22 @@
 package com.appsolve.wearther_backend.Service;
 
+import com.appsolve.wearther_backend.Entity.MemberEntity;
 import com.appsolve.wearther_backend.Repository.MemberRepository;
+import com.appsolve.wearther_backend.Repository.MemberTasteRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class MemberService {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired private MemberTasteRepository memberTasteRepository;
 
     public int getConstitutionByMemberId(Long memberId){
         int number = memberRepository.findConstitutionByMemberId(memberId);
@@ -21,5 +28,15 @@ public class MemberService {
         memberRepository.updateConstitutionByMemberId(memberId, constitution);
     }
 
+    public MemberEntity getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found with id: " + memberId));
+    }
 
+    public List<Long> getMemberTastes(Long memberId) {
+        return memberTasteRepository.findByMemberMemberId(memberId)
+                .stream()
+                .map(memberTaste -> memberTaste.getTaste().getId())
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/appsolve/wearther_backend/Service/TasteService.java
+++ b/src/main/java/com/appsolve/wearther_backend/Service/TasteService.java
@@ -1,0 +1,43 @@
+package com.appsolve.wearther_backend.Service;
+
+import com.appsolve.wearther_backend.init_data.repository.TasteLowerWearRepository;
+import com.appsolve.wearther_backend.init_data.repository.TasteOtherWearRepository;
+import com.appsolve.wearther_backend.init_data.repository.TasteUpperWearRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class TasteService {
+
+    private final TasteUpperWearRepository tasteUpperWearRepository;
+    private final TasteLowerWearRepository tasteLowerWearRepository;
+    private final TasteOtherWearRepository tasteOtherWearRepository;
+
+    public TasteService(TasteUpperWearRepository tasteUpperWearRepository, TasteLowerWearRepository tasteLowerWearRepository,
+                        TasteOtherWearRepository tasteOtherWearRepository) {
+        this.tasteUpperWearRepository = tasteUpperWearRepository;
+        this.tasteLowerWearRepository = tasteLowerWearRepository;
+        this.tasteOtherWearRepository = tasteOtherWearRepository;
+    }
+
+    public List<Long> getClothesByTasteId(Long tasteId, String clothingType) {
+        return switch (clothingType) {
+            case "upper" -> tasteUpperWearRepository.findByTasteId(tasteId)
+                    .stream()
+                    .map(tasteUpper -> tasteUpper.getUpperWear().getId())
+                    .collect(Collectors.toList());
+            case "lower" -> tasteLowerWearRepository.findByTasteId(tasteId)
+                    .stream()
+                    .map(tasteLower -> tasteLower.getLowerWear().getId())
+                    .collect(Collectors.toList());
+            case "other" -> tasteOtherWearRepository.findByTasteId(tasteId)
+                    .stream()
+                    .map(tasteOther -> tasteOther.getOtherWear().getId())
+                    .collect(Collectors.toList());
+            default -> Collections.emptyList();
+        };
+    }
+}

--- a/src/main/java/com/appsolve/wearther_backend/closet/api/ClosetController.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/api/ClosetController.java
@@ -61,7 +61,7 @@ public class ClosetController {
             others.addAll(recommendedClothes.getOthers());
         }
         ClosetResponseDto result = new ClosetResponseDto(new ArrayList<>(uppers), new ArrayList<>(lowers), new ArrayList<>(others));
-        return ResponseEntity.ok(result);
+        return ApiResponse.success(HttpStatus.OK, result);
     }
 
 }

--- a/src/main/java/com/appsolve/wearther_backend/closet/api/ClosetController.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/api/ClosetController.java
@@ -1,0 +1,34 @@
+package com.appsolve.wearther_backend.closet.api;
+
+import com.appsolve.wearther_backend.closet.dto.ClosetResponseDto;
+import com.appsolve.wearther_backend.closet.service.ClosetService;
+import com.appsolve.wearther_backend.member.Member;
+import com.appsolve.wearther_backend.member.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/closet")
+public class ClosetController {
+    private final ClosetService closetService;
+    private final MemberService memberService;
+
+    // TODO : 사용자 로그인 여부 체크 로직 추가 필요
+    // TODO : 인증 객체 사용하는 방법으로 멤버 찾아야 함.
+
+    @GetMapping("/clothes/{memberId}")
+    public ResponseEntity<?> getMemberCloset(@PathVariable("memberId") Long memberId) {
+        Member member = memberService.getMemberById(memberId);
+        ClosetResponseDto closetResponseDto = closetService.getClothes(memberId);
+        return ResponseEntity.ok(closetResponseDto);
+    }
+}

--- a/src/main/java/com/appsolve/wearther_backend/closet/api/ClosetController.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/api/ClosetController.java
@@ -1,34 +1,67 @@
 package com.appsolve.wearther_backend.closet.api;
 
+import com.appsolve.wearther_backend.Entity.MemberEntity;
+import com.appsolve.wearther_backend.Service.TasteService;
+import com.appsolve.wearther_backend.Service.MemberService;
+import com.appsolve.wearther_backend.apiResponse.ApiResponse;
 import com.appsolve.wearther_backend.closet.dto.ClosetResponseDto;
 import com.appsolve.wearther_backend.closet.service.ClosetService;
-import com.appsolve.wearther_backend.member.Member;
-import com.appsolve.wearther_backend.member.MemberService;
-import lombok.RequiredArgsConstructor;
+
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
 
 @Slf4j
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/api/closet")
 public class ClosetController {
     private final ClosetService closetService;
     private final MemberService memberService;
 
+    public ClosetController(ClosetService closetService, MemberService memberService, TasteService tasteService) {
+        this.closetService = closetService;
+        this.memberService = memberService;
+    }
+
     // TODO : 사용자 로그인 여부 체크 로직 추가 필요
-    // TODO : 인증 객체 사용하는 방법으로 멤버 찾아야 함.
+    // TODO : 테스트 위해 인증객체 대신 일단 아이디를 변수로 받아옴
 
     @GetMapping("/clothes/{memberId}")
     public ResponseEntity<?> getMemberCloset(@PathVariable("memberId") Long memberId) {
-        Member member = memberService.getMemberById(memberId);
-        ClosetResponseDto closetResponseDto = closetService.getClothes(memberId);
-        return ResponseEntity.ok(closetResponseDto);
+        // TODO : 인증 객체로부터 멤버를 가져옴
+        MemberEntity member = memberService.getMemberById(memberId);
+        ClosetResponseDto closetResponseDto = closetService.getOwnedClothes(memberId);
+        return ApiResponse.success(HttpStatus.OK, closetResponseDto);
     }
+
+    @GetMapping("/recommend/{memberId}")
+    public ResponseEntity<?> getRecommendedCloset(@PathVariable("memberId") Long memberId) {
+        // TODO : 인증 객체로부터 멤버를 가져옴
+        MemberEntity member = memberService.getMemberById(memberId);
+        List<Long> tasteIds = memberService.getMemberTastes(memberId);
+
+        Set<Long> uppers = new HashSet<>();
+        Set<Long> lowers = new HashSet<>();
+        Set<Long> others = new HashSet<>();
+
+        for (Long tasteId : tasteIds) {
+            ClosetResponseDto recommendedClothes = closetService.getClothesByTasteAndNotOwned(memberId, tasteId);
+            uppers.addAll(recommendedClothes.getUppers());
+            lowers.addAll(recommendedClothes.getLowers());
+            others.addAll(recommendedClothes.getOthers());
+        }
+        ClosetResponseDto result = new ClosetResponseDto(new ArrayList<>(uppers), new ArrayList<>(lowers), new ArrayList<>(others));
+        return ResponseEntity.ok(result);
+    }
+
 }

--- a/src/main/java/com/appsolve/wearther_backend/closet/dto/BuyRecommendDto.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/dto/BuyRecommendDto.java
@@ -1,0 +1,15 @@
+package com.appsolve.wearther_backend.closet.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BuyRecommendDto {
+    private String category;
+    private String productName;
+    private String productUrl;
+    private String mallName;
+}

--- a/src/main/java/com/appsolve/wearther_backend/closet/dto/ClosetResponseDto.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/dto/ClosetResponseDto.java
@@ -1,0 +1,16 @@
+package com.appsolve.wearther_backend.closet.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClosetResponseDto {
+    private List<Long> uppers;
+    private List<Long> lowers;
+    private List<Long> others;
+}

--- a/src/main/java/com/appsolve/wearther_backend/closet/entity/Closet.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/entity/Closet.java
@@ -1,0 +1,33 @@
+package com.appsolve.wearther_backend.closet.entity;
+
+
+import com.appsolve.wearther_backend.member.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name="closet")
+public class Closet {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="closet_id")
+    private Long id;
+
+    @OneToOne @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToMany(mappedBy = "closet", fetch = FetchType.LAZY)
+    private List<ClosetUpper> closetUppers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "closet", fetch = FetchType.LAZY)
+    private List<ClosetLower> closetLowers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "closet", fetch = FetchType.LAZY)
+    private List<ClosetOther> closetOthers = new ArrayList<>();
+}

--- a/src/main/java/com/appsolve/wearther_backend/closet/entity/Closet.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/entity/Closet.java
@@ -8,10 +8,12 @@ import lombok.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import static jakarta.persistence.FetchType.*;
+
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
+@Builder @Getter
 @Table(name="closet")
 public class Closet {
     @Id
@@ -22,12 +24,12 @@ public class Closet {
     @OneToOne @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "closet", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "closet", fetch = EAGER, cascade = CascadeType.ALL)
     private List<ClosetUpper> closetUppers = new ArrayList<>();
 
-    @OneToMany(mappedBy = "closet", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "closet", fetch = EAGER, cascade = CascadeType.ALL)
     private List<ClosetLower> closetLowers = new ArrayList<>();
 
-    @OneToMany(mappedBy = "closet", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "closet", fetch = EAGER, cascade = CascadeType.ALL)
     private List<ClosetOther> closetOthers = new ArrayList<>();
 }

--- a/src/main/java/com/appsolve/wearther_backend/closet/entity/Closet.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/entity/Closet.java
@@ -1,7 +1,7 @@
 package com.appsolve.wearther_backend.closet.entity;
 
 
-import com.appsolve.wearther_backend.member.Member;
+import com.appsolve.wearther_backend.Entity.MemberEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -22,7 +22,7 @@ public class Closet {
     private Long id;
 
     @OneToOne @JoinColumn(name = "member_id")
-    private Member member;
+    private MemberEntity member;
 
     @OneToMany(mappedBy = "closet", fetch = EAGER, cascade = CascadeType.ALL)
     private List<ClosetUpper> closetUppers = new ArrayList<>();

--- a/src/main/java/com/appsolve/wearther_backend/closet/entity/ClosetLower.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/entity/ClosetLower.java
@@ -1,0 +1,28 @@
+package com.appsolve.wearther_backend.closet.entity;
+
+import com.appsolve.wearther_backend.init_data.entity.LowerWear;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name="closet_lower")
+public class ClosetLower {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "closet_lower_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "closet_id")
+    private Closet closet;
+
+    @ManyToOne
+    @JoinColumn(name = "lower_wear_id")
+    private LowerWear lowerWear;
+}

--- a/src/main/java/com/appsolve/wearther_backend/closet/entity/ClosetLower.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/entity/ClosetLower.java
@@ -2,15 +2,12 @@ package com.appsolve.wearther_backend.closet.entity;
 
 import com.appsolve.wearther_backend.init_data.entity.LowerWear;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
+@Builder @Getter
 @Table(name="closet_lower")
 public class ClosetLower {
     @Id

--- a/src/main/java/com/appsolve/wearther_backend/closet/entity/ClosetOther.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/entity/ClosetOther.java
@@ -1,0 +1,25 @@
+package com.appsolve.wearther_backend.closet.entity;
+
+import com.appsolve.wearther_backend.init_data.entity.OtherWear;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name="closet_other")
+public class ClosetOther {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "closet_other_id")
+    private Long id;
+
+    @ManyToOne @JoinColumn(name = "closet_id")
+    private Closet closet;
+
+    @ManyToOne @JoinColumn(name = "other_wear_id")
+    private OtherWear otherWear;
+}

--- a/src/main/java/com/appsolve/wearther_backend/closet/entity/ClosetOther.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/entity/ClosetOther.java
@@ -2,15 +2,12 @@ package com.appsolve.wearther_backend.closet.entity;
 
 import com.appsolve.wearther_backend.init_data.entity.OtherWear;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
+@Builder @Getter
 @Table(name="closet_other")
 public class ClosetOther {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/appsolve/wearther_backend/closet/entity/ClosetUpper.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/entity/ClosetUpper.java
@@ -2,15 +2,12 @@ package com.appsolve.wearther_backend.closet.entity;
 
 import com.appsolve.wearther_backend.init_data.entity.UpperWear;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
+@Builder @Getter
 @Table(name="closet_upper")
 public class ClosetUpper {
     @Id

--- a/src/main/java/com/appsolve/wearther_backend/closet/entity/ClosetUpper.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/entity/ClosetUpper.java
@@ -1,0 +1,28 @@
+package com.appsolve.wearther_backend.closet.entity;
+
+import com.appsolve.wearther_backend.init_data.entity.UpperWear;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name="closet_upper")
+public class ClosetUpper {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "closet_upper_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "closet_id")
+    private Closet closet;
+
+    @ManyToOne
+    @JoinColumn(name = "upper_wear_id")
+    private UpperWear upperWear;
+}

--- a/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetLowerRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetLowerRepository.java
@@ -4,6 +4,9 @@ import com.appsolve.wearther_backend.closet.entity.ClosetLower;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ClosetLowerRepository extends JpaRepository<ClosetLower, Long> {
+    List<ClosetLower> findByClosetId(Long memberId);
 }

--- a/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetLowerRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetLowerRepository.java
@@ -1,0 +1,9 @@
+package com.appsolve.wearther_backend.closet.repository;
+
+import com.appsolve.wearther_backend.closet.entity.ClosetLower;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ClosetLowerRepository extends JpaRepository<ClosetLower, Long> {
+}

--- a/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetOtherRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetOtherRepository.java
@@ -4,6 +4,9 @@ import com.appsolve.wearther_backend.closet.entity.ClosetOther;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ClosetOtherRepository  extends JpaRepository<ClosetOther, Long> {
+    List<ClosetOther> findByClosetId(Long memberId);
 }

--- a/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetOtherRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetOtherRepository.java
@@ -1,0 +1,9 @@
+package com.appsolve.wearther_backend.closet.repository;
+
+import com.appsolve.wearther_backend.closet.entity.ClosetOther;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ClosetOtherRepository  extends JpaRepository<ClosetOther, Long> {
+}

--- a/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetRepository.java
@@ -1,14 +1,9 @@
 package com.appsolve.wearther_backend.closet.repository;
 
 import com.appsolve.wearther_backend.closet.entity.Closet;
-import com.appsolve.wearther_backend.closet.entity.ClosetLower;
-import com.appsolve.wearther_backend.closet.entity.ClosetOther;
-import com.appsolve.wearther_backend.closet.entity.ClosetUpper;
-import com.appsolve.wearther_backend.member.Member;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -18,14 +13,4 @@ import java.util.Optional;
 public interface ClosetRepository extends JpaRepository<Closet, Long> {
     @Query("SELECT c FROM Closet c WHERE c.id = :id")
     Optional<Closet> findClosetById(Long id);
-
-    @Query("SELECT cu FROM ClosetUpper cu JOIN FETCH cu.closet c WHERE c.id = :closetId")
-    List<ClosetUpper> findClosetUppersByClosetId(Long closetId);
-
-    @Query("SELECT cl FROM ClosetLower cl JOIN FETCH cl.closet c WHERE c.id = :closetId")
-    List<ClosetLower> findClosetLowersByClosetId(Long closetId);
-
-    @Query("SELECT co FROM ClosetOther co JOIN FETCH co.closet c WHERE c.id = :closetId")
-    List<ClosetOther> findClosetOthersByClosetId(Long closetId);
-
 }

--- a/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetRepository.java
@@ -1,0 +1,9 @@
+package com.appsolve.wearther_backend.closet.repository;
+
+import com.appsolve.wearther_backend.closet.entity.Closet;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ClosetRepository extends JpaRepository<Closet, Long> {
+}

--- a/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetRepository.java
@@ -1,9 +1,31 @@
 package com.appsolve.wearther_backend.closet.repository;
 
 import com.appsolve.wearther_backend.closet.entity.Closet;
+import com.appsolve.wearther_backend.closet.entity.ClosetLower;
+import com.appsolve.wearther_backend.closet.entity.ClosetOther;
+import com.appsolve.wearther_backend.closet.entity.ClosetUpper;
+import com.appsolve.wearther_backend.member.Member;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ClosetRepository extends JpaRepository<Closet, Long> {
+    @Query("SELECT c FROM Closet c WHERE c.id = :id")
+    Optional<Closet> findClosetById(Long id);
+
+    @Query("SELECT cu FROM ClosetUpper cu JOIN FETCH cu.closet c WHERE c.id = :closetId")
+    List<ClosetUpper> findClosetUppersByClosetId(Long closetId);
+
+    @Query("SELECT cl FROM ClosetLower cl JOIN FETCH cl.closet c WHERE c.id = :closetId")
+    List<ClosetLower> findClosetLowersByClosetId(Long closetId);
+
+    @Query("SELECT co FROM ClosetOther co JOIN FETCH co.closet c WHERE c.id = :closetId")
+    List<ClosetOther> findClosetOthersByClosetId(Long closetId);
+
 }

--- a/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetUpperRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetUpperRepository.java
@@ -4,6 +4,9 @@ import com.appsolve.wearther_backend.closet.entity.ClosetUpper;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ClosetUpperRepository extends JpaRepository<ClosetUpper, Long> {
+    List<ClosetUpper> findByClosetId(Long memberId);
 }

--- a/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetUpperRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetUpperRepository.java
@@ -1,0 +1,9 @@
+package com.appsolve.wearther_backend.closet.repository;
+
+import com.appsolve.wearther_backend.closet.entity.ClosetUpper;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ClosetUpperRepository extends JpaRepository<ClosetUpper, Long> {
+}

--- a/src/main/java/com/appsolve/wearther_backend/closet/service/ClosetService.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/service/ClosetService.java
@@ -1,37 +1,83 @@
 package com.appsolve.wearther_backend.closet.service;
 
+import com.appsolve.wearther_backend.Service.TasteService;
 import com.appsolve.wearther_backend.closet.dto.ClosetResponseDto;
 import com.appsolve.wearther_backend.closet.repository.ClosetLowerRepository;
 import com.appsolve.wearther_backend.closet.repository.ClosetOtherRepository;
 import com.appsolve.wearther_backend.closet.repository.ClosetUpperRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 public class ClosetService {
-    @Autowired private ClosetUpperRepository closetUpperRepository;
-    @Autowired private ClosetLowerRepository closetLowerRepository;
-    @Autowired private ClosetOtherRepository closetOtherRepository;
+    private final ClosetUpperRepository closetUpperRepository;
+    private final ClosetLowerRepository closetLowerRepository;
+    private final ClosetOtherRepository closetOtherRepository;
+    private final TasteService tasteService;
 
-    public ClosetResponseDto getClothes(Long memberId) {
-        List<Long> uppers = closetUpperRepository.findByClosetId(memberId)
-                .stream()
-                .map(closetUpper -> closetUpper.getUpperWear().getId())
+    public ClosetService(ClosetUpperRepository closetUpperRepository, ClosetLowerRepository closetLowerRepository,
+                         ClosetOtherRepository closetOtherRepository, TasteService tasteService) {
+        this.closetUpperRepository = closetUpperRepository;
+        this.closetLowerRepository = closetLowerRepository;
+        this.closetOtherRepository = closetOtherRepository;
+        this.tasteService = tasteService;
+    }
+
+    public ClosetResponseDto getOwnedClothes(Long memberId) {
+        List<Long> ownedUppers = getOwnedClothesByType(memberId, "upper");
+        List<Long> ownedLowers = getOwnedClothesByType(memberId, "lower");
+        List<Long> ownedOthers = getOwnedClothesByType(memberId, "other");
+
+        return new ClosetResponseDto(ownedUppers, ownedLowers, ownedOthers);
+    }
+
+    public ClosetResponseDto getClothesByTasteAndNotOwned(Long memberId, Long tasteId) {
+        List<Long> ownedUppers = getOwnedClothesByType(memberId, "upper");
+        List<Long> ownedLowers = getOwnedClothesByType(memberId, "lower");
+        List<Long> ownedOthers = getOwnedClothesByType(memberId, "other");
+
+        List<Long> tasteUppers = tasteService.getClothesByTasteId(tasteId, "upper");
+        List<Long> tasteLowers = tasteService.getClothesByTasteId(tasteId, "lower");
+        List<Long> tasteOthers = tasteService.getClothesByTasteId(tasteId, "other");
+
+        List<Long> unownedUppers = filterUnownedClothes(ownedUppers, tasteUppers);
+        List<Long> unownedLowers = filterUnownedClothes(ownedLowers, tasteLowers);
+        List<Long> unownedOthers = filterUnownedClothes(ownedOthers, tasteOthers);
+
+        return new ClosetResponseDto(unownedUppers, unownedLowers, unownedOthers);
+    }
+
+    private List<Long> getOwnedClothesByType(Long memberId, String clothingType) {
+        switch (clothingType) {
+            case "upper":
+                return closetUpperRepository.findByClosetId(memberId)
+                        .stream()
+                        .map(closetUpper -> closetUpper.getUpperWear().getId())
+                        .collect(Collectors.toList());
+
+            case "lower":
+                return closetLowerRepository.findByClosetId(memberId)
+                        .stream()
+                        .map(closetLower -> closetLower.getLowerWear().getId())
+                        .collect(Collectors.toList());
+
+            case "other":
+                return closetOtherRepository.findByClosetId(memberId)
+                        .stream()
+                        .map(closetOther -> closetOther.getOtherWear().getId())
+                        .collect(Collectors.toList());
+
+            default:
+                return Collections.emptyList();
+        }
+    }
+
+    private List<Long> filterUnownedClothes(List<Long> ownedClothes, List<Long> tasteClothes) {
+        return tasteClothes.stream()
+                .filter(clothId -> !ownedClothes.contains(clothId))
                 .collect(Collectors.toList());
-
-        List<Long> lowers = closetLowerRepository.findByClosetId(memberId)
-                .stream()
-                .map(closetLower -> closetLower.getLowerWear().getId())
-                .collect(Collectors.toList());
-
-        List<Long> others = closetOtherRepository.findByClosetId(memberId)
-                .stream()
-                .map(closetOther -> closetOther.getOtherWear().getId())
-                .collect(Collectors.toList());
-
-        return new ClosetResponseDto(uppers, lowers, others);
     }
 }

--- a/src/main/java/com/appsolve/wearther_backend/closet/service/ClosetService.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/service/ClosetService.java
@@ -1,0 +1,37 @@
+package com.appsolve.wearther_backend.closet.service;
+
+import com.appsolve.wearther_backend.closet.dto.ClosetResponseDto;
+import com.appsolve.wearther_backend.closet.repository.ClosetLowerRepository;
+import com.appsolve.wearther_backend.closet.repository.ClosetOtherRepository;
+import com.appsolve.wearther_backend.closet.repository.ClosetUpperRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ClosetService {
+    @Autowired private ClosetUpperRepository closetUpperRepository;
+    @Autowired private ClosetLowerRepository closetLowerRepository;
+    @Autowired private ClosetOtherRepository closetOtherRepository;
+
+    public ClosetResponseDto getClothes(Long memberId) {
+        List<Long> uppers = closetUpperRepository.findByClosetId(memberId)
+                .stream()
+                .map(closetUpper -> closetUpper.getUpperWear().getId())
+                .collect(Collectors.toList());
+
+        List<Long> lowers = closetLowerRepository.findByClosetId(memberId)
+                .stream()
+                .map(closetLower -> closetLower.getLowerWear().getId())
+                .collect(Collectors.toList());
+
+        List<Long> others = closetOtherRepository.findByClosetId(memberId)
+                .stream()
+                .map(closetOther -> closetOther.getOtherWear().getId())
+                .collect(Collectors.toList());
+
+        return new ClosetResponseDto(uppers, lowers, others);
+    }
+}

--- a/src/main/java/com/appsolve/wearther_backend/init_data/entity/LowerWear.java
+++ b/src/main/java/com/appsolve/wearther_backend/init_data/entity/LowerWear.java
@@ -1,5 +1,6 @@
 package com.appsolve.wearther_backend.init_data.entity;
 
+import com.appsolve.wearther_backend.closet.entity.ClosetLower;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -28,6 +29,9 @@ public class LowerWear {
     @OneToMany(mappedBy = "lowerWear", fetch = LAZY)
     private List<TasteLowerWear> tasteLowerWears = new ArrayList<>();
 
-    @OneToMany(mappedBy = "lowerWear", fetch = LAZY)
+    @OneToMany(mappedBy ="lowerWear", fetch = LAZY)
     private List<WeatherLowerWear> weathers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "lowerWear", fetch = LAZY)
+    private List<ClosetLower> closets = new ArrayList<>();
 }

--- a/src/main/java/com/appsolve/wearther_backend/init_data/entity/OtherWear.java
+++ b/src/main/java/com/appsolve/wearther_backend/init_data/entity/OtherWear.java
@@ -8,7 +8,6 @@ import lombok.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import static jakarta.persistence.FetchType.EAGER;
 import static jakarta.persistence.FetchType.LAZY;
 
 @Entity

--- a/src/main/java/com/appsolve/wearther_backend/init_data/entity/OtherWear.java
+++ b/src/main/java/com/appsolve/wearther_backend/init_data/entity/OtherWear.java
@@ -1,5 +1,6 @@
 package com.appsolve.wearther_backend.init_data.entity;
 
+import com.appsolve.wearther_backend.closet.entity.ClosetOther;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -7,6 +8,7 @@ import lombok.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import static jakarta.persistence.FetchType.EAGER;
 import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
@@ -25,6 +27,9 @@ public class OtherWear {
     @OneToMany(mappedBy = "otherWear", fetch = LAZY)
     private List<TasteOtherWear> tasteOtherWears = new ArrayList<>();
 
-    @OneToMany(mappedBy = "otherWear", fetch = LAZY)
+    @OneToMany(mappedBy ="otherWear", fetch = LAZY)
     private List<WeatherOtherWear> weathers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "otherWear", fetch = LAZY)
+    private List<ClosetOther> closets = new ArrayList<>();
 }

--- a/src/main/java/com/appsolve/wearther_backend/init_data/entity/UpperWear.java
+++ b/src/main/java/com/appsolve/wearther_backend/init_data/entity/UpperWear.java
@@ -1,5 +1,6 @@
 package com.appsolve.wearther_backend.init_data.entity;
 
+import com.appsolve.wearther_backend.closet.entity.ClosetUpper;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -30,4 +31,7 @@ public class UpperWear {
 
     @OneToMany(mappedBy = "upperWear", fetch = LAZY)
     private List<WeatherUpperWear> weathers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "upperWear", fetch = LAZY)
+    private List<ClosetUpper> closets = new ArrayList<>();
 }

--- a/src/main/java/com/appsolve/wearther_backend/init_data/repository/TasteLowerWearRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/init_data/repository/TasteLowerWearRepository.java
@@ -3,5 +3,9 @@ package com.appsolve.wearther_backend.init_data.repository;
 import com.appsolve.wearther_backend.init_data.entity.TasteLowerWear;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
+
 public interface TasteLowerWearRepository extends JpaRepository<TasteLowerWear, Long> {
+    List<TasteLowerWear> findByTasteId(Long tasteId);
 }

--- a/src/main/java/com/appsolve/wearther_backend/init_data/repository/TasteOtherWearRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/init_data/repository/TasteOtherWearRepository.java
@@ -4,6 +4,10 @@ import com.appsolve.wearther_backend.init_data.entity.TasteOtherWear;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
+
 @Repository
 public interface TasteOtherWearRepository extends JpaRepository<TasteOtherWear, Long> {
+    List<TasteOtherWear> findByTasteId(Long tasteId);
 }

--- a/src/main/java/com/appsolve/wearther_backend/init_data/repository/TasteUpperWearRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/init_data/repository/TasteUpperWearRepository.java
@@ -4,6 +4,10 @@ import com.appsolve.wearther_backend.init_data.entity.TasteUpperWear;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
+
 @Repository
 public interface TasteUpperWearRepository extends JpaRepository<TasteUpperWear, Long> {
+    List<TasteUpperWear> findByTasteId(Long tasteId);
 }


### PR DESCRIPTION
### ✨ 관련된 이슈
- close #3 
- close #8 

### 🙌 작업 내용
- 사용자가 보유한 옷을 조회할 수 있습니다.
- 사용자의 취향에 해당하지만, 사용자가 보유하지 않은 옷을 조회할 수 있습니다.
- DTO를 이용해서 각각의 경우에 대해 상의 아이디 리스트, 하의 아이디 리스트, 기타 아이디 리스트로 결과를 반환하게 했습니다.


### 📸 스크린샷 (선택)
📍 사용자가 보유한 옷 조회
![image](https://github.com/user-attachments/assets/f450ac15-0d3e-4e4d-8698-76ff9d0936c3)
![image](https://github.com/user-attachments/assets/38539c96-6902-4949-99d4-3b5934d8624e)

📍추천 상품 조회 (DB에 저장된 의상-취향 결과 토대로 결과 직접 확인해봤습니다!)
![image](https://github.com/user-attachments/assets/c673e0c7-99a0-4732-a3d3-3f6017302ab7)
![image](https://github.com/user-attachments/assets/6ebe1907-11ae-463d-982e-096c1c2f344f)


### 🤔 리뷰 요구사항(선택)
- 테스트를 위해 코드로 유저 데이터 넣고 작업했습니다. 
- 현재 기능 구현 및 확인을 위해서 path variable로 memberId를 받아와서 조회하는 형태로 작성했습니다.  request header 이용해서 **프론트에서 전달하는 Authorization 토큰으로부터 멤버를 가져와서** 다음 로직 진행하는 형태로 진행해야 할 거 같은데, 이 부분은 추후 일괄 수정하겠습니다.
- 현재는 기능 위주로 봐주시면 좋을 것 같습니다!!
- 원래 구매 연결도 구현한 후에 같이 PR하려고 했는데 성격이 다른 것 같아서 따로 PR하겠습니다.