### PR TITLE
[FEAT] 사용자 보유 옷 수정

### DIFF
--- a/src/main/java/com/appsolve/wearther_backend/closet/api/ClosetController.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/api/ClosetController.java
@@ -5,15 +5,13 @@ import com.appsolve.wearther_backend.Service.TasteService;
 import com.appsolve.wearther_backend.Service.MemberService;
 import com.appsolve.wearther_backend.apiResponse.ApiResponse;
 import com.appsolve.wearther_backend.closet.dto.ClosetResponseDto;
+import com.appsolve.wearther_backend.closet.dto.ClosetUpdateRequestDto;
 import com.appsolve.wearther_backend.closet.service.ClosetService;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -63,5 +61,14 @@ public class ClosetController {
         ClosetResponseDto result = new ClosetResponseDto(new ArrayList<>(uppers), new ArrayList<>(lowers), new ArrayList<>(others));
         return ApiResponse.success(HttpStatus.OK, result);
     }
+
+    @PatchMapping("/update/{memberId}")
+    public ResponseEntity<?> updateUserCloset(@PathVariable("memberId") Long memberId,
+                                              @RequestBody ClosetUpdateRequestDto updateRequestDto) {
+        // 사용자가 보유한 옷을 업데이트
+        closetService.updateUserCloset(memberId, updateRequestDto.getUppers(), updateRequestDto.getLowers(), updateRequestDto.getOthers());
+        return ApiResponse.success(HttpStatus.OK, updateRequestDto);
+    }
+
 
 }

--- a/src/main/java/com/appsolve/wearther_backend/closet/dto/ClosetUpdateRequestDto.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/dto/ClosetUpdateRequestDto.java
@@ -1,0 +1,13 @@
+package com.appsolve.wearther_backend.closet.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ClosetUpdateRequestDto {
+    private List<Long> uppers;
+    private List<Long> lowers;
+    private List<Long> others;
+
+}

--- a/src/main/java/com/appsolve/wearther_backend/closet/entity/Closet.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/entity/Closet.java
@@ -25,17 +25,14 @@ public class Closet {
     private MemberEntity member;
 
     @Builder.Default
-    @OneToMany(mappedBy = "closet", fetch = EAGER, cascade = CascadeType.ALL)
     @OneToMany(mappedBy = "closet", fetch = EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ClosetUpper> closetUppers = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "closet", fetch = EAGER, cascade = CascadeType.ALL)
     @OneToMany(mappedBy = "closet", fetch = EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ClosetLower> closetLowers = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "closet", fetch = EAGER, cascade = CascadeType.ALL)
     @OneToMany(mappedBy = "closet", fetch = EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ClosetOther> closetOthers = new ArrayList<>();
 }

--- a/src/main/java/com/appsolve/wearther_backend/closet/entity/Closet.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/entity/Closet.java
@@ -24,12 +24,12 @@ public class Closet {
     @OneToOne @JoinColumn(name = "member_id")
     private MemberEntity member;
 
-    @OneToMany(mappedBy = "closet", fetch = EAGER, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "closet", fetch = EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ClosetUpper> closetUppers = new ArrayList<>();
 
-    @OneToMany(mappedBy = "closet", fetch = EAGER, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "closet", fetch = EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ClosetLower> closetLowers = new ArrayList<>();
 
-    @OneToMany(mappedBy = "closet", fetch = EAGER, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "closet", fetch = EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ClosetOther> closetOthers = new ArrayList<>();
 }

--- a/src/main/java/com/appsolve/wearther_backend/closet/entity/ClosetUpper.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/entity/ClosetUpper.java
@@ -7,8 +7,9 @@ import lombok.*;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder @Getter
-@Table(name="closet_upper")
+@Builder
+@Getter
+@Table(name = "closet_upper")
 public class ClosetUpper {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetLowerRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetLowerRepository.java
@@ -2,11 +2,16 @@ package com.appsolve.wearther_backend.closet.repository;
 
 import com.appsolve.wearther_backend.closet.entity.ClosetLower;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ClosetLowerRepository extends JpaRepository<ClosetLower, Long> {
     List<ClosetLower> findByClosetId(Long memberId);
+
+    Optional<ClosetLower> findByClosetIdAndLowerWearId(Long closetId, Long lowerWearId);
+
 }

--- a/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetOtherRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetOtherRepository.java
@@ -2,11 +2,16 @@ package com.appsolve.wearther_backend.closet.repository;
 
 import com.appsolve.wearther_backend.closet.entity.ClosetOther;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ClosetOtherRepository  extends JpaRepository<ClosetOther, Long> {
     List<ClosetOther> findByClosetId(Long memberId);
+
+    Optional<ClosetOther> findByClosetIdAndOtherWearId(Long closetId, Long otherWearId);
+
 }

--- a/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetUpperRepository.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/repository/ClosetUpperRepository.java
@@ -2,11 +2,16 @@ package com.appsolve.wearther_backend.closet.repository;
 
 import com.appsolve.wearther_backend.closet.entity.ClosetUpper;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ClosetUpperRepository extends JpaRepository<ClosetUpper, Long> {
     List<ClosetUpper> findByClosetId(Long memberId);
+
+    Optional<ClosetUpper> findByClosetIdAndUpperWearId(Long closetId, Long upperWearId);
+
 }

--- a/src/main/java/com/appsolve/wearther_backend/closet/service/ClosetService.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/service/ClosetService.java
@@ -2,28 +2,56 @@ package com.appsolve.wearther_backend.closet.service;
 
 import com.appsolve.wearther_backend.Service.TasteService;
 import com.appsolve.wearther_backend.closet.dto.ClosetResponseDto;
+import com.appsolve.wearther_backend.closet.entity.Closet;
+import com.appsolve.wearther_backend.closet.entity.ClosetLower;
+import com.appsolve.wearther_backend.closet.entity.ClosetOther;
+import com.appsolve.wearther_backend.closet.entity.ClosetUpper;
 import com.appsolve.wearther_backend.closet.repository.ClosetLowerRepository;
 import com.appsolve.wearther_backend.closet.repository.ClosetOtherRepository;
+import com.appsolve.wearther_backend.closet.repository.ClosetRepository;
 import com.appsolve.wearther_backend.closet.repository.ClosetUpperRepository;
+import com.appsolve.wearther_backend.init_data.entity.LowerWear;
+import com.appsolve.wearther_backend.init_data.entity.OtherWear;
+import com.appsolve.wearther_backend.init_data.entity.UpperWear;
+import com.appsolve.wearther_backend.init_data.repository.LowerWearRepository;
+import com.appsolve.wearther_backend.init_data.repository.OtherWearRepository;
+import com.appsolve.wearther_backend.init_data.repository.UpperWearRepository;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional
 public class ClosetService {
     private final ClosetUpperRepository closetUpperRepository;
     private final ClosetLowerRepository closetLowerRepository;
     private final ClosetOtherRepository closetOtherRepository;
+    private final ClosetRepository closetRepository;
     private final TasteService tasteService;
+    private final UpperWearRepository upperWearRepository;  // UpperWearRepository 추가
+    private final LowerWearRepository lowerWearRepository;  // LowerWearRepository 추가
+    private final OtherWearRepository otherWearRepository;
+    private final EntityManager entityManager;
 
     public ClosetService(ClosetUpperRepository closetUpperRepository, ClosetLowerRepository closetLowerRepository,
-                         ClosetOtherRepository closetOtherRepository, TasteService tasteService) {
+                         ClosetOtherRepository closetOtherRepository, ClosetRepository closetRepository,
+                         UpperWearRepository upperWearRepository, LowerWearRepository lowerWearRepository,
+                         OtherWearRepository otherWearRepository,TasteService tasteService, EntityManager entityManager) {
         this.closetUpperRepository = closetUpperRepository;
         this.closetLowerRepository = closetLowerRepository;
         this.closetOtherRepository = closetOtherRepository;
+        this.upperWearRepository = upperWearRepository;
+        this.lowerWearRepository = lowerWearRepository;
+        this.otherWearRepository = otherWearRepository;
+        this.closetRepository = closetRepository;
         this.tasteService = tasteService;
+        this.entityManager = entityManager;
     }
 
     public ClosetResponseDto getOwnedClothes(Long memberId) {
@@ -79,5 +107,66 @@ public class ClosetService {
         return tasteClothes.stream()
                 .filter(clothId -> !ownedClothes.contains(clothId))
                 .collect(Collectors.toList());
+    }
+
+
+    public void updateUserCloset(Long memberId, List<Long> newUppers, List<Long> newLowers, List<Long> newOthers) {
+        // 기존 옷장 조회
+        Closet closet = closetRepository.findClosetById(memberId)
+                .orElseThrow(() -> new RuntimeException("Closet not found"));
+
+        // 기존 옷 데이터를 삭제하고 새로운 목록으로 업데이트 (clear()로 기존 목록 비우기)
+        closet.getClosetUppers().clear(); // 기존 UpperWear 삭제
+        closet.getClosetLowers().clear(); // 기존 LowerWear 삭제
+        closet.getClosetOthers().clear(); // 기존 OtherWear 삭제
+
+        // 새로운 옷을 추가
+        addNewClothes(closet, newUppers, newLowers, newOthers);
+
+        // 업데이트된 옷장을 저장
+        closetRepository.save(closet);
+    }
+
+
+    private void addNewClothes(Closet closet, List<Long> newUppers, List<Long> newLowers, List<Long> newOthers) {
+        // 새로운 UpperWear 추가
+        for (Long upperId : newUppers) {
+            ClosetUpper closetUpper = new ClosetUpper(null, closet, findUpperWearById(upperId));
+            closet.getClosetUppers().add(closetUpper); // 새 UpperWear 추가
+        }
+
+        // 새로운 LowerWear 추가
+        for (Long lowerId : newLowers) {
+            // 중복되지 않도록 확인
+            if (closetLowerRepository.findByClosetIdAndLowerWearId(closet.getId(), lowerId).isEmpty()) {
+                ClosetLower closetLower = new ClosetLower(null, closet, findLowerWearById(lowerId));
+                closet.getClosetLowers().add(closetLower); // 새 LowerWear 추가
+            }
+        }
+
+        // 새로운 OtherWear 추가
+        for (Long otherId : newOthers) {
+            // 중복되지 않도록 확인
+            if (closetOtherRepository.findByClosetIdAndOtherWearId(closet.getId(), otherId).isEmpty()) {
+                ClosetOther closetOther = new ClosetOther(null, closet, findOtherWearById(otherId));
+                closet.getClosetOthers().add(closetOther); // 새 OtherWear 추가
+            }
+        }
+    }
+
+    // 각 의류 ID로 의류 엔티티를 찾는 메서드 수정
+    private UpperWear findUpperWearById(Long upperId) {
+        return upperWearRepository.findById(upperId)
+                .orElseThrow(() -> new RuntimeException("Upper Wear not found"));
+    }
+
+    private LowerWear findLowerWearById(Long lowerId) {
+        return lowerWearRepository.findById(lowerId)
+                .orElseThrow(() -> new RuntimeException("Lower Wear not found"));
+    }
+
+    private OtherWear findOtherWearById(Long otherId) {
+        return otherWearRepository.findById(otherId)
+                .orElseThrow(() -> new RuntimeException("Other Wear not found"));
     }
 }

--- a/src/main/java/com/appsolve/wearther_backend/closet/service/ClosetService.java
+++ b/src/main/java/com/appsolve/wearther_backend/closet/service/ClosetService.java
@@ -111,50 +111,34 @@ public class ClosetService {
 
 
     public void updateUserCloset(Long memberId, List<Long> newUppers, List<Long> newLowers, List<Long> newOthers) {
-        // 기존 옷장 조회
         Closet closet = closetRepository.findClosetById(memberId)
                 .orElseThrow(() -> new RuntimeException("Closet not found"));
 
-        // 기존 옷 데이터를 삭제하고 새로운 목록으로 업데이트 (clear()로 기존 목록 비우기)
-        closet.getClosetUppers().clear(); // 기존 UpperWear 삭제
-        closet.getClosetLowers().clear(); // 기존 LowerWear 삭제
-        closet.getClosetOthers().clear(); // 기존 OtherWear 삭제
+        closet.getClosetUppers().clear();
+        closet.getClosetLowers().clear();
+        closet.getClosetOthers().clear();
 
-        // 새로운 옷을 추가
         addNewClothes(closet, newUppers, newLowers, newOthers);
 
-        // 업데이트된 옷장을 저장
         closetRepository.save(closet);
     }
 
 
     private void addNewClothes(Closet closet, List<Long> newUppers, List<Long> newLowers, List<Long> newOthers) {
-        // 새로운 UpperWear 추가
         for (Long upperId : newUppers) {
-            ClosetUpper closetUpper = new ClosetUpper(null, closet, findUpperWearById(upperId));
-            closet.getClosetUppers().add(closetUpper); // 새 UpperWear 추가
+            closet.getClosetUppers().add(new ClosetUpper(null, closet, findUpperWearById(upperId)));
         }
 
-        // 새로운 LowerWear 추가
         for (Long lowerId : newLowers) {
-            // 중복되지 않도록 확인
-            if (closetLowerRepository.findByClosetIdAndLowerWearId(closet.getId(), lowerId).isEmpty()) {
-                ClosetLower closetLower = new ClosetLower(null, closet, findLowerWearById(lowerId));
-                closet.getClosetLowers().add(closetLower); // 새 LowerWear 추가
-            }
+            closet.getClosetLowers().add(new ClosetLower(null, closet, findLowerWearById(lowerId)));
         }
 
-        // 새로운 OtherWear 추가
         for (Long otherId : newOthers) {
-            // 중복되지 않도록 확인
-            if (closetOtherRepository.findByClosetIdAndOtherWearId(closet.getId(), otherId).isEmpty()) {
-                ClosetOther closetOther = new ClosetOther(null, closet, findOtherWearById(otherId));
-                closet.getClosetOthers().add(closetOther); // 새 OtherWear 추가
-            }
+            closet.getClosetOthers().add(new ClosetOther(null, closet, findOtherWearById(otherId)));
         }
     }
 
-    // 각 의류 ID로 의류 엔티티를 찾는 메서드 수정
+
     private UpperWear findUpperWearById(Long upperId) {
         return upperWearRepository.findById(upperId)
                 .orElseThrow(() -> new RuntimeException("Upper Wear not found"));

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,2 +1,0 @@
-INSERT INTO closet (closet_id, member_id)
-VALUES (3, 3);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,2 @@
+INSERT INTO closet (closet_id, member_id)
+VALUES (3, 3);


### PR DESCRIPTION
### ✨ 관련된 이슈
- close #17 

### 🙌 작업 내용
- 사용자 보유 옷 수정 (patch)
- 사용자가 보유한 옷을 수정하면 그 내용을 받아서 해당 사용자의 기존 보유한 옷 내용을 모두 삭제하고 다시 레코드를 추가하도록 했습니다.

### 📸 스크린샷 (선택)

🔽 연재님이 만드신 get api로 사용자 보유 옷 조회 (member id = 1)
![closet5](https://github.com/user-attachments/assets/c8db9704-31ce-408d-989b-574f775933b4)

🔽 **patch 해보기**
![closet6](https://github.com/user-attachments/assets/41be8e71-5d3e-49e8-8375-29d77e5903af)

🔽 **patch 실행 결과**
![closet7](https://github.com/user-attachments/assets/d9c56467-e6d1-4f72-a01c-8a75a1b3a6c9)

🔽 get으로 한 번 더 조회 (잘 수정됨)
![closet8](https://github.com/user-attachments/assets/20bb3a55-780f-4d51-a5e1-189f333e277c)




### 🤔 리뷰 요구사항(선택)
-  post는 없어서 더미 데이터로 확인했습니다 😄 